### PR TITLE
Bug-fix: Use base Controller namespace to be the Illuminate nampespace

### DIFF
--- a/src/Http/Controllers/LanguageController.php
+++ b/src/Http/Controllers/LanguageController.php
@@ -2,7 +2,7 @@
 
 namespace Joedixon\NovaTranslation\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use JoeDixon\Translation\Drivers\Translation;
 use JoeDixon\Translation\Http\Requests\LanguageRequest;
 

--- a/src/Http/Controllers/LanguageTranslationController.php
+++ b/src/Http/Controllers/LanguageTranslationController.php
@@ -5,7 +5,7 @@ namespace Joedixon\NovaTranslation\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Pagination\Paginator;
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use JoeDixon\Translation\Drivers\Translation;
 use JoeDixon\Translation\Http\Requests\TranslationRequest;
 


### PR DESCRIPTION
using ` App\Http\Controllers\Controller` breaks Package if the Project uses a different namespace like `Core\Http\Controllers\Controller`.